### PR TITLE
nConnect client connects to multi servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,7 @@ You can enable UDP support when starting nConnect server with tuna mode,
 
 ### Use nConnect as library
 
-You can also use nConnect as library. Please check [socks5_proxy_test.go](tests/socks5_proxy_test.go) for usages.
-
+You can also use nConnect as library. Please check [proxy_test.go](tests/proxy_test.go) for usages.
 
 ### Use pre-built Docker image
 
@@ -255,6 +254,44 @@ docker run --rm -it --net=host -v ${PWD}:/nConnect/data nknorg/nconnect
 ```
 
 followed by the command line argument you want to add.
+
+## nConnect Client Connects to Multi Servers
+
+Now nConnect client can connect to multi servers. You can edit `config.json` to add multi servers admin address:
+
+```
+
+{
+  "Client": true,
+  "Server": false,
+  "identifier": "alice",
+  "seed": "",
+  "remoteAdminAddr": [
+      "nConnect.bob1.7cafe0ae02789f8eb6b293e46b0ac5cf8f92f73042199c8161e5b5f90b13dcb5",
+      "nConnect.bob2.7cafe0ae02789f8eb6b293e46b0ac5cf8f92f73042199c8161e5b5f90b13dcb5",
+      "nConnect.bob3.7cafe0ae02789f8eb6b293e46b0ac5cf8f92f73042199c8161e5b5f90b13dcb5",
+  ],
+  "localSocksAddr": "127.0.0.1:1080",
+}
+
+```
+
+After config multi `remoteAdminAddr`, the nConnect client will add routing infomation to each Servers' local IP. So you can access all the servers by their local IP address.
+
+Specifically, the first  item in the `remoteAdminAddr` will become the default server which will get the forwarded data which targets are beyond all these servers' local IP address. Such as access to website by domain, or some other applications.
+
+You can use command argument to connects to multi servers too. Use multi times argument `-a` to pass multi servers addresses:
+
+```
+
+$ nConnect -c -a server-address1 -a server-address2 -a server-address3
+
+```
+
+
+## Use `config.json` to Simplify Command Arguments
+
+You can use `config.json` to simpliy command arguments. Move config.client.json or config.server.json as `config.json` and edit it before starting your nConnect client or server. After saving `config.json`, you can start nConnect simply.
 
 ## Contributing
 

--- a/config.client.json
+++ b/config.client.json
@@ -1,0 +1,13 @@
+{
+    "Client": true,
+    "Server": false,
+    "identifier": "",
+    "seed": "",
+    "remoteAdminAddr": [],
+    "localSocksAddr": "127.0.0.1:1080",
+    "tuna": true,
+    "udp": true,
+    "acceptAddrs": null,
+    "adminAddrs": null
+}
+  

--- a/config.server.json
+++ b/config.server.json
@@ -1,0 +1,14 @@
+{
+    "Client": false,
+    "Server": true,
+    "identifier": "",
+    "seed": "",
+    "remoteAdminAddr": [],
+    "localSocksAddr": "",
+    "tuna": true,
+    "udp": true,
+    "adminIdentifier": "nConnect",
+    "webRootPath": "web/dist",
+    "acceptAddrs": [],
+    "adminAddrs": []
+}

--- a/config/config.go
+++ b/config/config.go
@@ -72,8 +72,8 @@ type Config struct {
 	LogAPIResponseSize int    `json:"logAPIResponseSize,omitempty" long:"log-api-response-size" description:"(server only) Maximum size in bytes of get log api response. If log size is greater than this value, only the lastest part of the log will be returned."`
 
 	// Remote address
-	RemoteAdminAddr  string `json:"remoteAdminAddr,omitempty" short:"a" long:"remote-admin-addr" description:"(client only) Remote server admin address"`
-	RemoteTunnelAddr string `json:"remoteTunnelAddr,omitempty" short:"r" long:"remote-tunnel-addr" description:"(client only) Remote server tunnel address, not needed if remote server admin address is given"`
+	RemoteAdminAddr  []string `json:"remoteAdminAddr,omitempty" short:"a" long:"remote-admin-addr" description:"(client only) Remote server admin address"`
+	RemoteTunnelAddr []string `json:"remoteTunnelAddr,omitempty" short:"r" long:"remote-tunnel-addr" description:"(client only) Remote server tunnel address, not needed if remote server admin address is given"`
 
 	// Socks proxy config
 	LocalSocksAddr string `json:"localSocksAddr,omitempty" short:"l" long:"local-socks-addr" description:"(client only) Local socks proxy listen address" default:"127.0.0.1:1080"`

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/nknorg/ncp-go v1.0.6-0.20230228002512-f4cd1740bebd
 	github.com/nknorg/nkn-sdk-go v1.4.6-0.20230404044330-ad192f36d07e
 	github.com/nknorg/nkn-tuna-session v0.2.6-0.20230512052928-f91bbbdcdaf6
-	github.com/nknorg/nkn-tunnel v0.3.5-0.20230512210146-4b6e5700365c
+	github.com/nknorg/nkn-tunnel v0.3.5-0.20230621222635-47610787d9ae
 	github.com/nknorg/nkn/v2 v2.2.0
 	github.com/nknorg/nkngomobile v0.0.0-20220615081414-671ad1afdfa9
 	github.com/nknorg/tuna v0.0.0-20230405223335-eb60c60c5953

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/nknorg/nkn-sdk-go v1.4.6-0.20230404044330-ad192f36d07e h1:lWKUEfqOJ9N
 github.com/nknorg/nkn-sdk-go v1.4.6-0.20230404044330-ad192f36d07e/go.mod h1:mnI1+17p2cI+5wv+3CWRyCjSALqUg5k1jTaWC2h0f/M=
 github.com/nknorg/nkn-tuna-session v0.2.6-0.20230512052928-f91bbbdcdaf6 h1:S+HzmSp4Yd97+X9xZ5AmcQgkbstEry+hfl8O42dX/kA=
 github.com/nknorg/nkn-tuna-session v0.2.6-0.20230512052928-f91bbbdcdaf6/go.mod h1:47W1/1axI4aOkQKtkjjRHW1x2SYrdCRI49LdPWf9vMc=
-github.com/nknorg/nkn-tunnel v0.3.5-0.20230512210146-4b6e5700365c h1:NKPl1qHZv5Lca+n/BtwyIlOOSar9ekQKa0z4/FCTJ4w=
-github.com/nknorg/nkn-tunnel v0.3.5-0.20230512210146-4b6e5700365c/go.mod h1:rOxPIUgtFwsZG1DEJM6mm/AfH3Z+le+oSEv8WhZ2LQA=
+github.com/nknorg/nkn-tunnel v0.3.5-0.20230621222635-47610787d9ae h1:cuexnKy8/RWm6WBIjqCjaGd/cUHDB1wQsTWiOR2Eagw=
+github.com/nknorg/nkn-tunnel v0.3.5-0.20230621222635-47610787d9ae/go.mod h1:rOxPIUgtFwsZG1DEJM6mm/AfH3Z+le+oSEv8WhZ2LQA=
 github.com/nknorg/nkn/v2 v2.2.0 h1:sXOawvVF/T3bBTuWbzBCyrGuxldA3be+f+BDjoWcOEA=
 github.com/nknorg/nkn/v2 v2.2.0/go.mod h1:yv3jkg0aOtN9BDHS4yerNSZJtJNBfGvlaD5K6wL6U3E=
 github.com/nknorg/nkngomobile v0.0.0-20220615081414-671ad1afdfa9 h1:Gr37j7Ttvcn8g7TdC5fs6Y6IJKdmfqCvj03UbsrS77o=

--- a/ss/multiconn.go
+++ b/ss/multiconn.go
@@ -1,0 +1,25 @@
+package ss
+
+import (
+	"strings"
+	"sync"
+)
+
+var routes struct {
+	sync.RWMutex
+	TargetToClient map[string]string // map target ip to local tunnel port
+	DefaultClient  string            // the default client for the targets are not in TargetToClient map
+}
+
+func getClient(target string) string {
+	tgtIp := strings.Split(target, ":")
+
+	routes.RLock()
+	defer routes.RUnlock()
+	server, ok := routes.TargetToClient[tgtIp[0]]
+
+	if ok {
+		return server
+	}
+	return routes.DefaultClient
+}

--- a/ss/ss.go
+++ b/ss/ss.go
@@ -30,6 +30,9 @@ type Config struct {
 	Verbose    bool
 	UDPTimeout time.Duration
 	TCPCork    bool
+
+	TargetToClient map[string]string // map target ip to local tunnel port
+	DefaultClient  string            // the default client for the targets are not in Target2Client map
 }
 
 var config struct {
@@ -46,6 +49,9 @@ func Start(flags *Config) error {
 	config.Verbose = flags.Verbose
 	config.UDPTimeout = flags.UDPTimeout
 	config.TCPCork = flags.TCPCork
+
+	routes.TargetToClient = flags.TargetToClient
+	routes.DefaultClient = flags.DefaultClient
 
 	var key []byte
 	if flags.Key != "" {

--- a/ss/tcp.go
+++ b/ss/tcp.go
@@ -67,6 +67,7 @@ func tcpLocal(addr, server string, shadow func(net.Conn) net.Conn, getAddr func(
 				return
 			}
 
+			server = getClient(tgt.String())
 			rc, err := net.Dial("tcp", server)
 			if err != nil {
 				logf("failed to connect to server %v: %v", server, err)

--- a/tests/client.json
+++ b/tests/client.json
@@ -6,7 +6,7 @@
   "cipher": "dummy",
   "logMaxSize": 1,
   "logMaxBackups": 3,
-  "remoteAdminAddr": "nConnect.bob.7cafe0ae02789f8eb6b293e46b0ac5cf8f92f73042199c8161e5b5f90b13dcb5",
+  "remoteAdminAddr": ["nConnect.bob.7cafe0ae02789f8eb6b293e46b0ac5cf8f92f73042199c8161e5b5f90b13dcb5"],
   "localSocksAddr": "127.0.0.1:1080",
   "tunAddr": "10.0.86.2",
   "tunGateway": "10.0.86.1",

--- a/tests/config.go
+++ b/tests/config.go
@@ -4,14 +4,15 @@ var port int = 1080
 var proxyAddr string = "127.0.0.1:1080"
 
 const (
-	rounds = 10
+	numMsgs = 10
 
 	seedHex = "e68e046d13dd911594576ba0f4a196e9666790dc492071ad9ea5972c0b940435"
 
-	tcpServerAddr  = "127.0.0.1:54321"
-	httpServerAddr = "127.0.0.1:54322"
-	udpServerAddr  = "127.0.0.1:54323"
-	httpServiceUrl = "http://" + httpServerAddr + "/httpEcho"
+	tcpPort  = ":54321"
+	httpPort = ":54322"
+	udpPort  = ":54323"
 
 	tunaNodeStarted = "tuna node is started"
 )
+
+var servers = []string{"127.0.0.1"} // {"10.10.0.15", "10.136.0.10"}

--- a/tests/dns.go
+++ b/tests/dns.go
@@ -8,7 +8,7 @@ import (
 )
 
 func dnsQuery() {
-	for i := 1; i <= rounds; i++ {
+	for i := 1; i <= numMsgs; i++ {
 		err := brook.Socks5Test(proxyAddr, "", "", "http3.ooo", "137.184.237.95", "8.8.8.8:53")
 		if err != nil {
 			fmt.Printf("TestDNSProxy try %v err: %v\n", i, err)

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -19,7 +19,9 @@ func TestProxy(t *testing.T) {
 	time.Sleep(15 * time.Second)
 
 	dnsQuery()
-	StartWebClient()
-	StartTCPClient()
-	StartUDPClient()
+	for _, server := range servers {
+		StartWebClient("http://" + server + httpPort + "/httpEcho")
+		StartTCPClient(server + tcpPort)
+		StartUDPClient(server + udpPort)
+	}
 }

--- a/tests/pub.go
+++ b/tests/pub.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 
 	"github.com/nknorg/nconnect"
 	"github.com/nknorg/nconnect/config"
@@ -19,17 +18,6 @@ import (
 )
 
 var ch chan string = make(chan string, 4)
-
-func waitFor(ch chan string, status string) {
-	fmt.Println("waiting for ", status)
-	for {
-		str := <-ch
-		fmt.Println("waitFor got: ", str)
-		if strings.Contains(str, status) {
-			break
-		}
-	}
-}
 
 func startNconnect(configFile string, tuna, udp, tun bool, n *types.Node) error {
 	b, err := os.ReadFile(configFile)
@@ -56,15 +44,16 @@ func startNconnect(configFile string, tuna, udp, tun bool, n *types.Node) error 
 		opts.LocalSocksAddr = proxyAddr
 		port++
 	}
+	fmt.Printf("opts.RemoteAdminAddr: %+v\n", opts.RemoteAdminAddr)
+
 	nc, _ := nconnect.NewNconnect(opts)
 	if opts.Server {
 		nc.SetTunaNode(n)
-		nc.StartServer()
+		err = nc.StartServer()
 	} else {
-		nc.StartClient()
+		err = nc.StartClient()
 	}
-
-	return nil
+	return err
 }
 
 func StartNconnectServerWithTunaNode(tuna, udp, tun bool) {

--- a/tests/tcp.go
+++ b/tests/tcp.go
@@ -10,11 +10,11 @@ import (
 )
 
 func StartTcpServer() error {
-	tcpServer, err := net.Listen("tcp", tcpServerAddr)
+	tcpServer, err := net.Listen("tcp", tcpPort)
 	if err != nil {
 		return err
 	}
-	fmt.Println("TCP Server is listening at ", tcpServerAddr)
+	fmt.Println("TCP Server is listening at ", tcpPort)
 
 	for {
 		conn, err := tcpServer.Accept()
@@ -28,7 +28,7 @@ func StartTcpServer() error {
 				fmt.Printf("StartTcpServer, Read err %v\n", err)
 				break
 			}
-
+			fmt.Printf("TCP Server got: %v\n", string(b[:n]))
 			_, err = conn.Write(b[:n])
 			if err != nil {
 				fmt.Printf("StartTcpServer, write err %v\n", err)
@@ -38,7 +38,7 @@ func StartTcpServer() error {
 	}
 }
 
-func StartTCPClient() error {
+func StartTCPClient(serverAddr string) error {
 	auth := proxy.Auth{User: "", Password: ""}
 	dailer, err := proxy.SOCKS5("tcp", proxyAddr, &auth, &net.Dialer{
 		Timeout:   60 * time.Second,
@@ -49,14 +49,15 @@ func StartTCPClient() error {
 		return err
 	}
 
-	conn, err := dailer.Dial("tcp", tcpServerAddr)
+	conn, err := dailer.Dial("tcp", serverAddr)
 	if err != nil {
 		fmt.Printf("StartTCPClient, dailer.Dial err: %v\n", err)
 		return err
 	}
+	fmt.Printf("StartTCPClient, dail to %v  success\n", serverAddr)
 
 	user := &Person{Name: "tcp_boy", Age: 0}
-	for i := 0; i < rounds; i++ {
+	for i := 0; i < numMsgs; i++ {
 		user.Age++
 		b1, _ := json.Marshal(user)
 		_, err = conn.Write(b1)
@@ -82,20 +83,21 @@ func StartTCPClient() error {
 			fmt.Printf("StartTCPClient, got wrong response, sent %+v, recv %+v\n", user, respUser)
 			break
 		}
+		fmt.Printf("Got echo %+v\n", respUser)
 	}
 
 	return nil
 }
 
-func StartTCPTunClient() error {
-	conn, err := net.Dial("tcp", tcpServerAddr)
+func StartTCPTunClient(serverAddr string) error {
+	conn, err := net.Dial("tcp", serverAddr)
 	if err != nil {
 		fmt.Printf("StartTCPClient, dailer.Dial err: %v\n", err)
 		return err
 	}
 
 	user := &Person{Name: "tcp_boy", Age: 0}
-	for i := 0; i < rounds; i++ {
+	for i := 0; i < numMsgs; i++ {
 		user.Age++
 		b1, _ := json.Marshal(user)
 		_, err = conn.Write(b1)

--- a/tests/tun_test.go
+++ b/tests/tun_test.go
@@ -8,7 +8,7 @@ import (
 
 // go test -v -run=TestTun
 func TestTun(t *testing.T) {
-	tuna, udp, tun := true, true, false
+	tuna, udp, tun := true, true, true
 	go func() {
 		err := startNconnect("client.json", tuna, udp, tun, nil)
 		if err != nil {
@@ -19,7 +19,9 @@ func TestTun(t *testing.T) {
 	time.Sleep(20 * time.Second)
 
 	dnsQuery()
-	StartTunWebClient()
-	StartTCPClient()
-	StartUDPClient()
+	for _, server := range servers {
+		StartTunWebClient("http://" + server + httpPort + "/httpEcho")
+		StartTCPClient(server + tcpPort)
+		StartUDPClient(server + udpPort)
+	}
 }

--- a/tests/udp.go
+++ b/tests/udp.go
@@ -11,7 +11,7 @@ import (
 )
 
 func StartUdpServer() error {
-	a, err := net.ResolveUDPAddr("udp", udpServerAddr)
+	a, err := net.ResolveUDPAddr("udp", udpPort)
 	if err != nil {
 		return err
 	}
@@ -20,7 +20,7 @@ func StartUdpServer() error {
 		return err
 	}
 
-	fmt.Printf("UDP server is listening at %v\n", udpServerAddr)
+	fmt.Printf("UDP server is listening at %v\n", udpPort)
 
 	b := make([]byte, 1024)
 	for {
@@ -41,12 +41,12 @@ func StartUdpServer() error {
 	return nil
 }
 
-func StartUDPClient() error {
+func StartUDPClient(serverAddr string) error {
 	s5c, err := socks5.NewClient(proxyAddr, "", "", 0, 60)
 	if err != nil {
 		return err
 	}
-	uc, err := s5c.Dial("udp", udpServerAddr)
+	uc, err := s5c.Dial("udp", serverAddr)
 	if err != nil {
 		fmt.Println("StartUDPClient.s5c.Dial err: ", err)
 		return err
@@ -54,7 +54,7 @@ func StartUDPClient() error {
 	defer uc.Close()
 
 	user := &Person{Name: "udp_boy", Age: 0}
-	for i := 0; i < rounds; i++ {
+	for i := 0; i < numMsgs; i++ {
 		user.Age++
 		send, _ := json.Marshal(user)
 		if _, err := uc.Write(send); err != nil {
@@ -71,6 +71,8 @@ func StartUDPClient() error {
 		if !bytes.Equal(recv[:n], send) {
 			fmt.Printf("StartUDPClient.recv %v is not as same as sent %v\n", string(recv[:n]), string(send))
 			break
+		} else {
+			fmt.Printf("StartUDPClient got echo: %v\n", string(recv[:n]))
 		}
 	}
 


### PR DESCRIPTION
1. Config multi servers' `remoteAdminAddr`;
2. Query servers' local IP for routing;
3. Set up nkn tunnel for each server;
4. Route data to each server by the server's local IP;
5. Route other data to the default tunnel if the IP or target is not in the routing table.