### PR TITLE
Modify testcases to avoid port confilict

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/nknorg/nconnect
 go 1.20
 
 require (
+	github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5
 	github.com/eycorsican/go-tun2socks v1.16.11
 	github.com/gin-contrib/gzip v0.0.3
 	github.com/gin-gonic/gin v1.9.0
@@ -16,6 +17,7 @@ require (
 	github.com/nknorg/nkngomobile v0.0.0-20220615081414-671ad1afdfa9
 	github.com/nknorg/tuna v0.0.0-20230405223335-eb60c60c5953
 	github.com/shadowsocks/go-shadowsocks2 v0.1.2
+	github.com/stretchr/testify v1.8.1
 	github.com/txthinking/brook v0.0.0-20230418095906-76ced63f1803
 	github.com/txthinking/socks5 v0.0.0-20230307062227-0e1677eca4ba
 	golang.org/x/net v0.8.0
@@ -27,6 +29,7 @@ require (
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/bytedance/sonic v1.8.0 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gaukas/godicttls v0.0.3 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
@@ -62,6 +65,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
 	github.com/phuslu/iploc v1.0.20230201 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qtls-go1-18 v0.2.0 // indirect
 	github.com/quic-go/qtls-go1-19 v0.2.0 // indirect
 	github.com/quic-go/qtls-go1-20 v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHG
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
 github.com/bytedance/sonic v1.8.0 h1:ea0Xadu+sHlu7x5O3gKhRpQ1IKiMrSiHttPF0ybECuA=
 github.com/bytedance/sonic v1.8.0/go.mod h1:i736AoUSYt75HyZLoJW9ERYxcy6eaN6h4BZXU064P/U=
+github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5 h1:BjkPE3785EwPhhyuFkbINB+2a1xATwk8SNDWnJiD41g=
+github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5/go.mod h1:jtAfVaU/2cu1+wdSRPWE2c1N2qeAA3K4RH9pYgqwets=
 github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06/go.mod h1:DH46F32mSOjUmXrMHnKwZdA8wcEefY7UVqBKYGjpdQY=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 h1:qSGYFH7+jGhDF8vLC+iwCD4WpbV1EBDSzWkJODFLams=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311/go.mod h1:b583jCggY9gE99b6G5LEC39OIiVsWj+R97kbl5odCEk=

--- a/tests/client.json
+++ b/tests/client.json
@@ -22,6 +22,7 @@
   "tunaMinFee": "0.00001",
   "tunaFeeRatio": 0.1,
   "tunaGeoDBPath": ".",
+  "tunaDisableMeasureBandwidth": false,
   "tunaMeasureStoragePath": ".",
   "adminIdentifier": "nConnect",
   "webRootPath": "web/dist",

--- a/tests/config.go
+++ b/tests/config.go
@@ -1,7 +1,6 @@
 package tests
 
 var port int = 1080
-var proxyAddr string = "127.0.0.1:1080"
 
 const (
 	numMsgs = 10

--- a/tests/dns.go
+++ b/tests/dns.go
@@ -2,18 +2,18 @@ package tests
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/txthinking/brook"
 )
 
-func dnsQuery() {
+func dnsQuery() error {
+	proxyAddr := fmt.Sprintf("127.0.0.1:%v", port)
 	for i := 1; i <= numMsgs; i++ {
 		err := brook.Socks5Test(proxyAddr, "", "", "http3.ooo", "137.184.237.95", "8.8.8.8:53")
 		if err != nil {
 			fmt.Printf("TestDNSProxy try %v err: %v\n", i, err)
-			time.Sleep(time.Duration(i) * time.Second)
-			break
+			return err
 		}
 	}
+	return nil
 }

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -1,9 +1,10 @@
 package tests
 
 import (
-	"fmt"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 // go test -v -run=TestProxy
@@ -11,17 +12,22 @@ func TestProxy(t *testing.T) {
 	tuna, udp, tun := true, true, false
 	go func() {
 		err := startNconnect("client.json", tuna, udp, tun, nil)
-		if err != nil {
-			fmt.Printf("start nconnect client err: %v\n", err)
-			return
-		}
+		require.NoError(t, err)
 	}()
-	time.Sleep(15 * time.Second)
 
-	dnsQuery()
+	time.Sleep(5 * time.Second)
+
+	err := waitSSAndTunaReady()
+	require.NoError(t, err)
+
+	err = dnsQuery()
+	require.NoError(t, err)
 	for _, server := range servers {
-		StartWebClient("http://" + server + httpPort + "/httpEcho")
-		StartTCPClient(server + tcpPort)
-		StartUDPClient(server + udpPort)
+		err := StartWebClient("http://" + server + httpPort + "/httpEcho")
+		require.NoError(t, err)
+		err = StartTCPClient(server + tcpPort)
+		require.NoError(t, err)
+		err = StartUDPClient(server + udpPort)
+		require.NoError(t, err)
 	}
 }

--- a/tests/server.json
+++ b/tests/server.json
@@ -23,6 +23,7 @@
   "tunaFeeRatio": 0.1,
   "tunaServiceName": "reverse",
   "tunaGeoDBPath": ".",
+  "tunaDisableMeasureBandwidth": false,
   "tunaMeasureStoragePath": ".",
   "adminIdentifier": "nConnect",
   "webRootPath": "web/dist",

--- a/tests/udp.go
+++ b/tests/udp.go
@@ -27,21 +27,20 @@ func StartUdpServer() error {
 		n, addr, err := udpServer.ReadFromUDP(b)
 		if err != nil {
 			fmt.Printf("StartUdpServer.ReadFromUDP err: %v\n", err)
-			break
+			return err
 		}
 
 		time.Sleep(100 * time.Millisecond)
 		_, _, err = udpServer.WriteMsgUDP(b[:n], nil, addr)
 		if err != nil {
 			fmt.Printf("StartUdpServer.WriteMsgUDP err: %v\n", err)
-			break
+			return err
 		}
 	}
-
-	return nil
 }
 
 func StartUDPClient(serverAddr string) error {
+	proxyAddr := fmt.Sprintf("127.0.0.1:%v", port)
 	s5c, err := socks5.NewClient(proxyAddr, "", "", 0, 60)
 	if err != nil {
 		return err
@@ -59,18 +58,17 @@ func StartUDPClient(serverAddr string) error {
 		send, _ := json.Marshal(user)
 		if _, err := uc.Write(send); err != nil {
 			fmt.Println("StartUDPClient.Write err ", err)
-			break
+			return err
 		}
 
 		recv := make([]byte, 512)
 		n, err := uc.Read(recv)
 		if err != nil {
 			fmt.Println("StartUDPClient.Read err ", err)
-			break
+			return err
 		}
 		if !bytes.Equal(recv[:n], send) {
-			fmt.Printf("StartUDPClient.recv %v is not as same as sent %v\n", string(recv[:n]), string(send))
-			break
+			return fmt.Errorf("StartUDPClient.recv %v is not as same as sent %v", string(recv[:n]), string(send))
 		} else {
 			fmt.Printf("StartUDPClient got echo: %v\n", string(recv[:n]))
 		}

--- a/tests/web.go
+++ b/tests/web.go
@@ -41,6 +41,7 @@ func httpEcho(w http.ResponseWriter, r *http.Request) {
 func StartWebClient(httpServUrl string) error {
 	fmt.Printf("http request to: %v\n", httpServUrl)
 
+	proxyAddr := fmt.Sprintf("127.0.0.1:%v", port)
 	socksProxy := "socks5://" + proxyAddr
 	proxy := func(_ *http.Request) (*url.URL, error) {
 		return url.Parse(socksProxy)
@@ -63,39 +64,38 @@ func StartWebClient(httpServUrl string) error {
 		err := json.NewEncoder(b).Encode(user)
 		if err != nil {
 			fmt.Printf("StartWebClient.Encode err: %v\n", err)
-			break
+			return err
 		}
 		req, err := http.NewRequest(http.MethodPost, httpServUrl, b)
 		req.Header.Set("Content-type", "application/json")
 
 		if err != nil {
 			fmt.Printf("StartWebClient.http.NewRequest err: %v\n", err)
-			break
+			return err
 		}
 
 		resp, err := httpClient.Do(req)
 		if err != nil {
 			fmt.Printf("StartWebClient.http.Do err: %v\n", err)
-			break
+			return err
 		}
 		defer resp.Body.Close()
 
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			fmt.Printf("StartWebClient.io.ReadAll err: %v\n", err)
-			break
+			return err
 		}
 
 		respUser := &Person{}
 		err = json.Unmarshal(body, respUser)
 		if err != nil {
 			fmt.Printf("StartWebClient.json.Unmarshal %v err: %v\n", string(body), err)
-			break
+			return err
 		}
 
 		if respUser.Age != user.Age {
-			fmt.Printf("StartWebClient got wrong response, sent %+v, recv %+v\n", user, respUser)
-			break
+			return fmt.Errorf("StartWebClient got wrong response, sent %+v, recv %+v", user, respUser)
 		} else {
 			fmt.Printf("StartWebClient got echo: %+v\n", respUser)
 		}
@@ -119,39 +119,38 @@ func StartTunWebClient(httpServUrl string) error {
 		err := json.NewEncoder(b).Encode(user)
 		if err != nil {
 			fmt.Printf("StartWebClient.Encode err: %v\n", err)
-			break
+			return err
 		}
 		req, err := http.NewRequest(http.MethodPost, httpServUrl, b)
 		req.Header.Set("Content-type", "application/json")
 
 		if err != nil {
 			fmt.Printf("StartWebClient.http.NewRequest err: %v\n", err)
-			break
+			return err
 		}
 
 		resp, err := httpClient.Do(req)
 		if err != nil {
 			fmt.Printf("StartWebClient.http.Do err: %v\n", err)
-			break
+			return err
 		}
 		defer resp.Body.Close()
 
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			fmt.Printf("StartWebClient.io.ReadAll err: %v\n", err)
-			break
+			return err
 		}
 
 		respUser := &Person{}
 		err = json.Unmarshal(body, respUser)
 		if err != nil {
 			fmt.Printf("StartWebClient.json.Unmarshal err: %v\n", err)
-			break
+			return err
 		}
 
 		if respUser.Age != user.Age {
-			fmt.Printf("StartWebClient got wrong response, sent %+v, recv %+v\n", user, respUser)
-			break
+			return fmt.Errorf("StartWebClient got wrong response, sent %+v, recv %+v", user, respUser)
 		}
 	}
 


### PR DESCRIPTION
Modify testcases to:
1. Avoid port confilict;
2. Check and wait tuna connections are ready;
3. Check and wait socks proxy is ready.
4. Add argument `-remoteTuna` to use remote Tuna Node;
5. Add argument `-tun` to test tun device mode at root shell.