### PR TITLE
Export tunnels to get tuna session OnConnect

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/nknorg/nconnect
 go 1.20
 
 require (
-	github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5
 	github.com/eycorsican/go-tun2socks v1.16.11
 	github.com/gin-contrib/gzip v0.0.3
 	github.com/gin-gonic/gin v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,6 @@ github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHG
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
 github.com/bytedance/sonic v1.8.0 h1:ea0Xadu+sHlu7x5O3gKhRpQ1IKiMrSiHttPF0ybECuA=
 github.com/bytedance/sonic v1.8.0/go.mod h1:i736AoUSYt75HyZLoJW9ERYxcy6eaN6h4BZXU064P/U=
-github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5 h1:BjkPE3785EwPhhyuFkbINB+2a1xATwk8SNDWnJiD41g=
-github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5/go.mod h1:jtAfVaU/2cu1+wdSRPWE2c1N2qeAA3K4RH9pYgqwets=
 github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06/go.mod h1:DH46F32mSOjUmXrMHnKwZdA8wcEefY7UVqBKYGjpdQY=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 h1:qSGYFH7+jGhDF8vLC+iwCD4WpbV1EBDSzWkJODFLams=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311/go.mod h1:b583jCggY9gE99b6G5LEC39OIiVsWj+R97kbl5odCEk=

--- a/nconnect.go
+++ b/nconnect.go
@@ -559,3 +559,7 @@ func (nc *nconnect) waitForSignal() {
 func (nc *nconnect) SetTunaNode(node *types.Node) {
 	nc.tunaNode = node
 }
+
+func (nc *nconnect) GetTunnels() []*tunnel.Tunnel {
+	return nc.tunnels
+}

--- a/tests/dns.go
+++ b/tests/dns.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/txthinking/brook"
 )
@@ -11,6 +12,9 @@ func dnsQuery() error {
 	for i := 1; i <= numMsgs; i++ {
 		err := brook.Socks5Test(proxyAddr, "", "", "http3.ooo", "137.184.237.95", "8.8.8.8:53")
 		if err != nil {
+			if strings.Contains(err.Error(), "timeout") { // sometimes the DNS reply timeout, retry
+				continue
+			}
 			fmt.Printf("TestDNSProxy try %v err: %v\n", i, err)
 			return err
 		}

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/nknorg/tuna/types"
 )
 
-var remoteTuna = flag.Bool("remoteTuna", false, "use remote tuna node")
+var remoteTuna = flag.Bool("remoteTuna", false, "use remote tuna nodes")
 var tun = flag.Bool("tun", false, "use tun device")
 
 func TestMain(m *testing.M) {
@@ -19,7 +19,7 @@ func TestMain(m *testing.M) {
 	if *remoteTuna {
 		fmt.Println("We are using remote tuna node")
 	} else {
-		fmt.Println("Using local tuna node. If want to use remote tuna node, please run: go test -v -remoteTuna .")
+		fmt.Println("Using local tuna node. If want to use remote tuna nodes, please run: go test -v -remoteTuna .")
 	}
 
 	go func() {
@@ -54,15 +54,13 @@ func TestMain(m *testing.M) {
 		}
 	}
 
-	go func() {
-		err := startNconnect("server.json", true, true, false, tunaNode)
-		if err != nil {
-			log.Fatalf("start nconnect server err: %v", err)
-			return
-		}
-	}()
+	err = startNconnect("server.json", true, true, false, tunaNode)
+	if err != nil {
+		log.Fatalf("start nconnect server err: %v", err)
+		return
+	}
 
-	time.Sleep(15 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	exitVal := m.Run()
 	os.Exit(exitVal)

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -17,7 +17,7 @@ func TestProxy(t *testing.T) {
 
 	time.Sleep(5 * time.Second)
 
-	err := waitSSAndTunaReady()
+	err := waitForSSProxReady()
 	require.NoError(t, err)
 
 	err = dnsQuery()

--- a/tests/tun_test.go
+++ b/tests/tun_test.go
@@ -24,7 +24,7 @@ func TestTun(t *testing.T) {
 
 	time.Sleep(10 * time.Second)
 
-	err := waitSSAndTunaReady()
+	err := waitForSSProxReady()
 	require.NoError(t, err)
 
 	err = dnsQuery()


### PR DESCRIPTION
1. `nconnect` export tunnels by getting method;
2. Wait for tunnel tuna-session OnConnect;
3. Remove go-netstat dependancy which is not compatible on MAC OS;
4. Check proxy ready by dialing up.